### PR TITLE
Adding a new module that allows export to csv of top youth players

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -253,6 +253,7 @@ a good reason to. They are for version bumps in Makefile.
 				<string>content/shortcuts-and-tweaks/copy-match-id.js</string>
 				<string>content/shortcuts-and-tweaks/copy-player-ad.js</string>
 				<string>content/shortcuts-and-tweaks/copy-youth.js</string>
+				<string>content/shortcuts-and-tweaks/export-top-youth-players.js</string>
 				<string>content/shortcuts-and-tweaks/extra-shortcuts.js</string>
 				<string>content/shortcuts-and-tweaks/filter.js</string>
 				<string>content/shortcuts-and-tweaks/lineup-shortcut.js</string>

--- a/content/background.html
+++ b/content/background.html
@@ -198,6 +198,7 @@
 	<script type="application/x-javascript" src="./shortcuts-and-tweaks/copy-match-id.js"></script>
 	<script type="application/x-javascript" src="./shortcuts-and-tweaks/copy-player-ad.js"></script>
 	<script type="application/x-javascript" src="./shortcuts-and-tweaks/copy-youth.js"></script>
+	<script type="application/x-javascript" src="./shortcuts-and-tweaks/export-top-youth-players.js"></script>
 	<script type="application/x-javascript" src="./shortcuts-and-tweaks/extra-shortcuts.js"></script>
 	<script type="application/x-javascript" src="./shortcuts-and-tweaks/filter.js"></script>
 	<script type="application/x-javascript" src="./shortcuts-and-tweaks/lineup-shortcut.js"></script>

--- a/content/bootstrap-firefox.js
+++ b/content/bootstrap-firefox.js
@@ -236,6 +236,7 @@ FoxtrickFirefox.prototype = {
 		'shortcuts-and-tweaks/copy-match-id.js',
 		'shortcuts-and-tweaks/copy-player-ad.js',
 		'shortcuts-and-tweaks/copy-youth.js',
+		'shortcuts-and-tweaks/export-top-youth-players.js',
 		'shortcuts-and-tweaks/extra-shortcuts.js',
 		'shortcuts-and-tweaks/filter.js',
 		'shortcuts-and-tweaks/lineup-shortcut.js',

--- a/content/foxtrick.properties
+++ b/content/foxtrick.properties
@@ -520,6 +520,9 @@ module.U20LastMatch.YouthPlayers.desc=Show last official U20 match in the Youth 
 module.U20LastMatch.SeniorPlayers.desc=Show last official U20 match in the Senior Player Details page.
 module.U20LastMatch.AllPlayers.desc=Show last official U20 match in the Senior/Youth/NT Players page.
 
+# ExportTopYouth
+module.ExportTopYouth.desc=Export top youth players to csv
+
 # -----------------------------------------------------------------------------
 
 # IN-GAME STRINGS. translate first
@@ -1772,6 +1775,17 @@ LocalTime.hattrick=Hattrick time
 LocalTime.hattrick.title=Time in Hattrick time zone. Click the clock to switch to local time.
 LocalTime.local=Local time
 LocalTime.local.title=Time in local time zone. Click the clock to switch to Hattrick time.
+
+# ExportTopYouth
+ExportTopYouth.exportToCsv=Export to CSV
+ExportTopYouth.header.id=Id
+ExportTopYouth.header.name=Name
+ExportTopYouth.header.years=Years
+ExportTopYouth.header.days=Days
+ExportTopYouth.header.toPromote=Days to promotion
+ExportTopYouth.header.specialty=Specialty
+ExportTopYouth.header.stars=Stars
+ExportTopYouth.header.position=Position
 
 team.status.booked=Friendly booked
 

--- a/content/foxtrick.properties
+++ b/content/foxtrick.properties
@@ -1786,6 +1786,7 @@ ExportTopYouth.header.toPromote=Days to promotion
 ExportTopYouth.header.specialty=Specialty
 ExportTopYouth.header.stars=Stars
 ExportTopYouth.header.position=Position
+ExportTopYouth.header.minutesPlayed=Minutes Played
 
 team.status.booked=Friendly booked
 

--- a/content/pages.js
+++ b/content/pages.js
@@ -161,6 +161,7 @@ Foxtrick.htPages = {
 	'statsMatchesHeadToHead'    : '/World/Stats/StatsMatchesHeadToHead.aspx',
 	'statsSeries'               : '/World/Series/Stats.aspx',
 	'statsTopPlayers'           : '/World/Players/TopPlayers.aspx',
+	'statsTopYouthPlayers'      : '/World/Players/TopYouthPlayers.aspx',
 	'supporters'                : '/Club/Supporters/(Default.aspx?|?)actionType=mysupporters',
 	'supported'                 : '/Club/Supporters/(Default.aspx$|$)',
 	'hallOfFame'                : '/Club/HallOfFame/(Default.aspx|?|$)',

--- a/content/preferences.html
+++ b/content/preferences.html
@@ -209,6 +209,7 @@
 	<script type="application/x-javascript" src="./shortcuts-and-tweaks/copy-match-id.js"></script>
 	<script type="application/x-javascript" src="./shortcuts-and-tweaks/copy-player-ad.js"></script>
 	<script type="application/x-javascript" src="./shortcuts-and-tweaks/copy-youth.js"></script>
+	<script type="application/x-javascript" src="./shortcuts-and-tweaks/export-top-youth-players.js"></script>
 	<script type="application/x-javascript" src="./shortcuts-and-tweaks/extra-shortcuts.js"></script>
 	<script type="application/x-javascript" src="./shortcuts-and-tweaks/filter.js"></script>
 	<script type="application/x-javascript" src="./shortcuts-and-tweaks/lineup-shortcut.js"></script>

--- a/content/resources/css/export-top-youth-players.css
+++ b/content/resources/css/export-top-youth-players.css
@@ -1,0 +1,4 @@
+.exportLink {
+	float: right;
+	padding-bottom: 5px;
+}

--- a/content/scripts-fennec.js
+++ b/content/scripts-fennec.js
@@ -237,6 +237,7 @@ Foxtrick.loader.background.contentScriptManager = {
 		'shortcuts-and-tweaks/copy-match-id.js',
 		'shortcuts-and-tweaks/copy-player-ad.js',
 		'shortcuts-and-tweaks/copy-youth.js',
+		'shortcuts-and-tweaks/export-top-youth-players.js',
 		'shortcuts-and-tweaks/extra-shortcuts.js',
 		'shortcuts-and-tweaks/filter.js',
 		'shortcuts-and-tweaks/lineup-shortcut.js',

--- a/content/shortcuts-and-tweaks/export-top-youth-players.js
+++ b/content/shortcuts-and-tweaks/export-top-youth-players.js
@@ -51,7 +51,7 @@ Foxtrick.modules['ExportTopYouth'] = {
 			let link = doc.createElement("a");
 			link.setAttribute("href", encodedUri);
 			link.setAttribute("download", getFileName());
-			link.innerHTML = Foxtrick.L10n.getString('exportToCsv');
+			link.innerHTML = Foxtrick.L10n.getString('ExportTopYouth.exportToCsv');
 			link.className = 'exportLink';
 			panel.parentNode.insertBefore(link, panel);
 		};
@@ -118,7 +118,7 @@ Foxtrick.modules['ExportTopYouth'] = {
 		};
 
 		const addMinutesPlayed = function (youthPlayerId) {
-			if(processed > 50) {
+			if(Object.keys(players).length > 50) {
 				return;
 			}
 			const params = [

--- a/content/shortcuts-and-tweaks/export-top-youth-players.js
+++ b/content/shortcuts-and-tweaks/export-top-youth-players.js
@@ -1,0 +1,113 @@
+'use strict';
+/**
+* export-top-youth-players.js
+* Export to csv functions to top youth players
+* @author fgaldeano, maurooaranda
+*/
+
+Foxtrick.modules['ExportTopYouth'] = {
+	MODULE_CATEGORY: Foxtrick.moduleCategories.SHORTCUTS_AND_TWEAKS,
+	PAGES: ['statsTopYouthPlayers'],
+	OPTIONS: [],
+	CSS: Foxtrick.InternalPath + 'resources/css/export-top-youth-players.css',
+	run: function(doc) {
+		if (!Foxtrick.isPage(doc, 'statsTopYouthPlayers')) {
+			return;
+		}
+		const results = doc.querySelectorAll('#pnlResult > div.mainBox > table.tablesorter > tbody > tr');
+		if(results.length === 0) { //No Search performed
+			return;
+		} 
+		const panel = doc.querySelector('#pnlResult');
+		const playerType = doc.querySelector('#ctl00_ctl00_CPContent_CPMain_ddlPosition');
+		const ageInput = doc.querySelector('#ctl00_ctl00_CPContent_CPMain_txtAge');
+		let csvContent = "data:text/csv;charset=utf-8,";
+
+		const getExportData = function() {
+		    let playerPosition = playerType.options[playerType.selectedIndex].text;
+		    const header = [
+		    	Foxtrick.L10n.getString('ExportTopYouth.header.name'), 
+				Foxtrick.L10n.getString('ExportTopYouth.header.id'), 
+				Foxtrick.L10n.getString('ExportTopYouth.header.years'), 
+				Foxtrick.L10n.getString('ExportTopYouth.header.days'), 
+				Foxtrick.L10n.getString('ExportTopYouth.header.toPromote'), 
+				Foxtrick.L10n.getString('ExportTopYouth.header.specialty'), 
+				Foxtrick.L10n.getString('ExportTopYouth.header.stars'), 
+				Foxtrick.L10n.getString('ExportTopYouth.header.position')
+			];
+			csvContent += header.join(',') + '\r\n';
+			for(let tr of results) {
+				let row = getRowFromTR(tr).join(',') + "," + playerPosition;
+				csvContent += row + '\r\n';
+			}
+		};
+		
+		const addExportButton = function() {
+			let encodedUri = encodeURI(csvContent);
+			let link = doc.createElement("a");
+			link.setAttribute("href", encodedUri);
+			link.setAttribute("download", getFileName());
+			link.innerHTML = Foxtrick.L10n.getString('exportToCsv');
+			link.className = 'exportLink';
+			panel.parentNode.insertBefore(link, panel);
+		};
+		
+		const getRowFromTR = function(tr) {
+			let rowArray = [];
+			let index = 0;
+			for(let td of tr.querySelectorAll('td')) {
+				let images = td.querySelectorAll('img');
+				let playerLink = td.querySelector('a');
+				let innerText = td.innerText.trim();
+			    if(index === 0 && playerLink) {
+					rowArray.push(innerText);
+					rowArray.push(playerLink.href.substring(playerLink.href.indexOf('=') + 1));
+				}
+				if(index === 1 && innerText.indexOf('(') !== -1) {
+					let splitted = innerText.split(' (');
+					rowArray.push(splitted[0]);
+					rowArray.push(splitted[1].substring(0, splitted[1].length - 1));
+				}
+				if(index > 1 && index < 4) {
+					rowArray.push(innerText);
+				}
+				if(index === 4 && images.length > 0) {
+					rowArray.push(getNumberFromStars(images));
+				}
+				index++;
+			}    
+			return rowArray;
+		};
+
+		const getNumberFromStars = function(images) {
+			let number = 0;
+			for(let img of images) {
+				if(img.className.indexOf('starBig') !== -1) {
+					number += 5;
+				}
+				if(img.className.indexOf('starWhole') !== -1) {
+					number += 1;
+				}
+				if(img.className.indexOf('starHalf') !== -1) {
+					number += 0.5;
+				}
+			}
+
+			return number;
+		};
+
+		const getFileName = function() {
+		    if (playerType.selectedIndex == -1)
+		        return null;
+		    let rawAge = ageInput.value;
+		    let age = parseInt(rawAge);
+		    if ((age == "NaN") || (age > 17 || age < 15))
+			return playerType.options[playerType.selectedIndex].text.replace(' ', '_') + '.csv';
+		    else
+			return playerType.options[playerType.selectedIndex].text.replace(' ', '_') + ' (' + rawAge + ')' + '.csv';
+		};
+
+		getExportData();
+		addExportButton();
+	}
+};

--- a/content/shortcuts-and-tweaks/export-top-youth-players.js
+++ b/content/shortcuts-and-tweaks/export-top-youth-players.js
@@ -104,14 +104,15 @@ Foxtrick.modules['ExportTopYouth'] = {
 		};
 
 		const getFileName = function() {
-		    if (playerType.selectedIndex == -1)
-		        return null;
-		    let rawAge = ageInput.value;
-		    let age = parseInt(rawAge);
-		    if (!age || age > 17 || age < 15) {
+			if (playerType.selectedIndex == -1) {
+				return 'Players.csv';
+			}
+			let rawAge = ageInput.value;
+			let age = parseInt(rawAge);
+			if (!age || age > 17 || age < 15) {
 				return playerType.options[playerType.selectedIndex].text.replace(' ', '_') + '.csv';
 			}
-		    else {
+			else {
 				return playerType.options[playerType.selectedIndex].text.replace(' ', '_') + ' (' + rawAge + ')' + '.csv';
 			}
 		};

--- a/defaults/preferences/foxtrick.js
+++ b/defaults/preferences/foxtrick.js
@@ -765,3 +765,4 @@ pref("extensions.foxtrick.prefs.logDisabled", true);
 pref("extensions.foxtrick.prefs.volume", "100");
 pref("extensions.foxtrick.prefs.module.MobileEnhancements.ViewPort.enabled", true);
 pref("extensions.foxtrick.prefs.module.MobileEnhancements.ViewPort_text", "320");
+pref("extensions.foxtrick.prefs.module.ExportTopYouth.enabled", true);

--- a/manifest.json
+++ b/manifest.json
@@ -240,6 +240,7 @@
 			"content/shortcuts-and-tweaks/copy-match-id.js",
 			"content/shortcuts-and-tweaks/copy-player-ad.js",
 			"content/shortcuts-and-tweaks/copy-youth.js",
+			"content/shortcuts-and-tweaks/export-top-youth-players.js",
 			"content/shortcuts-and-tweaks/extra-shortcuts.js",
 			"content/shortcuts-and-tweaks/filter.js",
 			"content/shortcuts-and-tweaks/lineup-shortcut.js",

--- a/modules
+++ b/modules
@@ -135,6 +135,7 @@ shortcuts-and-tweaks/copy-bb-ad.js
 shortcuts-and-tweaks/copy-match-id.js
 shortcuts-and-tweaks/copy-player-ad.js
 shortcuts-and-tweaks/copy-youth.js
+shortcuts-and-tweaks/export-top-youth-players.js
 shortcuts-and-tweaks/extra-shortcuts.js
 shortcuts-and-tweaks/filter.js
 shortcuts-and-tweaks/lineup-shortcut.js


### PR DESCRIPTION
Functionality would be greatly appreciated by U17 scounts, mainly.
It adds a link to the results table of youth players and let you export them to a csv file.

- Module logic in content/shortcuts-and-tweaks/export-top-youth-players.js
- Module style in content/resources/css/export-top-youth-players.css
- Added /World/Players/TopYouthPlayers.aspx to pages

The original requests came to me from Argentinian U17 scouts, where I participate. I am pretty sure other functionality would be coming from them.
But, at the moment I would like to see if this can go into foxtrick.