### PR TITLE
implement ratings for new match order page

### DIFF
--- a/Info.plist
+++ b/Info.plist
@@ -205,6 +205,7 @@ a good reason to. They are for version bumps in Makefile.
 				<string>content/matches/match-lineup-fixes.js</string>
 				<string>content/matches/match-lineup-tweaks.js</string>
 				<string>content/matches/match-order.js</string>
+				<string>content/matches/match-order-new.js</string>
 				<string>content/matches/match-player-colouring.js</string>
 				<string>content/matches/match-ratings-tweaks.js</string>
 				<string>content/matches/match-report-format.js</string>

--- a/content/background.html
+++ b/content/background.html
@@ -151,6 +151,7 @@
 	<script type="application/x-javascript" src="./matches/match-lineup-fixes.js"></script>
 	<script type="application/x-javascript" src="./matches/match-lineup-tweaks.js"></script>
 	<script type="application/x-javascript" src="./matches/match-order.js"></script>
+	<script type="application/x-javascript" src="./matches/match-order-new.js"></script>
 	<script type="application/x-javascript" src="./matches/match-player-colouring.js"></script>
 	<script type="application/x-javascript" src="./matches/match-ratings-tweaks.js"></script>
 	<script type="application/x-javascript" src="./matches/match-report-format.js"></script>

--- a/content/bootstrap-firefox.js
+++ b/content/bootstrap-firefox.js
@@ -188,6 +188,7 @@ FoxtrickFirefox.prototype = {
 		'matches/match-lineup-fixes.js',
 		'matches/match-lineup-tweaks.js',
 		'matches/match-order.js',
+		'matches/match-order-new.js',
 		'matches/match-player-colouring.js',
 		'matches/match-ratings-tweaks.js',
 		'matches/match-report-format.js',

--- a/content/matches/match-order-new.js
+++ b/content/matches/match-order-new.js
@@ -1,0 +1,96 @@
+'use strict';
+/**
+ * match-order-new.js
+ * @author jazzzzz
+ */
+
+Foxtrick.modules.MatchOrderNew = {
+    MODULE_CATEGORY: Foxtrick.moduleCategories.MATCHES,
+    PAGES: ['matchOrderNew'],
+    OPTIONS: ['UseRatingsModule'],
+    CSS: Foxtrick.InternalPath + 'resources/css/match-simulator.css',
+	TACTIC_NAMES: [
+		'normal', 'pressing',
+		'ca', 'aim', 'aow',
+		'', '',
+		'creatively', 'longshots',
+	],
+
+    run: function (doc) {
+        var module = this;
+
+        var IS_YOUTH = Foxtrick.Pages.Match.isYouth(doc);
+        if (IS_YOUTH)
+            return;
+
+
+        var useRatings = Foxtrick.Prefs.isModuleEnabled('Ratings') &&
+            Foxtrick.Prefs.isModuleOptionEnabled(module, 'UseRatingsModule');
+
+        // ratings
+        if (useRatings) {
+            var ratingsDiv = Foxtrick.createFeaturedElement(doc, module, 'div');
+            ratingsDiv.id = 'ft_simulation_ratings';
+            var ratingsLabel = doc.createElement('h2');
+            ratingsDiv.appendChild(ratingsLabel).textContent =
+                Foxtrick.L10n.getString('matchOrder.ratings');
+            var ratingsTable = doc.createElement('table');
+            ratingsDiv.appendChild(ratingsTable).id = 'ft_simulation_ratings_table';
+            document.getElementById("content").appendChild(ratingsDiv);
+
+            setTimeout(function(){
+                document.querySelector(".ht-tabs-wizard").addEventListener('click', function(){
+                    setTimeout(addUpdateListener, 1000);
+                });
+                setTimeout(addUpdateListener, 1000);
+            }, 2000);
+        }
+
+
+		var updateRatings = function () {
+			var ratings = Array.from(document.querySelectorAll('.mo-field-rating-predicitons span.ng-binding:not(.mo-field-rating-predicitons-diff)'))
+				.map(elem => [elem.textContent - 1,0] );
+			if(ratings.length===0){
+				return;
+			}
+			Foxtrick.modules['Ratings'].initHtRatings();
+
+			var tactics = Foxtrick.modules.MatchOrderNew.TACTIC_NAMES[doc.getElementById('mo-tacticType').value];
+			var tacticLevel = Foxtrick.L10n.getLevelFromText(document.querySelector('.mo-field-rating-predicitons-tactic span').textContent.trim());
+			if(tacticLevel){
+				tacticLevel = tacticLevel.toString();
+			}
+
+			var ratingsTable = doc.getElementById('ft_simulation_ratings_table');
+			var newTable = ratingsTable.cloneNode(false);
+			Foxtrick.modules['Ratings'].addRatings(
+				doc, newTable,
+				ratings[3], ratings[0], ratings[1], ratings[2], ratings[4], ratings[5], ratings[6],
+				[tactics,''], [tacticLevel,""], false
+			);
+
+			ratingsTable.parentNode.replaceChild(newTable, ratingsTable);
+		}
+
+		function addUpdateListener() {
+			MutationObserver = window.MutationObserver || window.WebKitMutationObserver;
+
+			let predictionsDomElement = document.querySelector(".mo-field-rating-predicitons-holder");
+			if(!predictionsDomElement ){
+				return;
+			}
+			var observer = new MutationObserver(function (mutations, observer) {
+				updateRatings();
+			});
+
+			observer.observe(predictionsDomElement, {
+				subtree: true,
+				attributes: false,
+				characterData: true,
+				childList: true
+			});
+			updateRatings();
+		}
+
+    }
+};

--- a/content/pages.js
+++ b/content/pages.js
@@ -84,6 +84,7 @@ Foxtrick.htPages = {
 	'matchReferees'             : '/Club/Matches/Referees.aspx',
 	'matchesLive'               : '/Club/Matches/Live.aspx',
 	'matchOrder'                : '/MatchOrder/(Default.aspx|?|$)',
+	'matchOrderNew'             : '/MatchOrder/Matchorder.aspx',
 	'matchOrderSimple'          : '/MatchOrder/Simple.aspx',
 	'flagCollection'            : '/Club/Flags/(Default.aspx|?|$)',
 	'teamPage'                  : '/Club/(Default.aspx|?|$)',

--- a/content/preferences.html
+++ b/content/preferences.html
@@ -162,6 +162,7 @@
 	<script type="application/x-javascript" src="./matches/match-lineup-fixes.js"></script>
 	<script type="application/x-javascript" src="./matches/match-lineup-tweaks.js"></script>
 	<script type="application/x-javascript" src="./matches/match-order.js"></script>
+	<script type="application/x-javascript" src="./matches/match-order-new.js"></script>
 	<script type="application/x-javascript" src="./matches/match-player-colouring.js"></script>
 	<script type="application/x-javascript" src="./matches/match-ratings-tweaks.js"></script>
 	<script type="application/x-javascript" src="./matches/match-report-format.js"></script>

--- a/content/scripts-fennec.js
+++ b/content/scripts-fennec.js
@@ -193,6 +193,7 @@ Foxtrick.loader.background.contentScriptManager = {
 		'matches/match-lineup-fixes.js',
 		'matches/match-lineup-tweaks.js',
 		'matches/match-order.js',
+		'matches/match-order-new.js',
 		'matches/match-player-colouring.js',
 		'matches/match-ratings-tweaks.js',
 		'matches/match-report-format.js',

--- a/defaults/preferences/foxtrick.js
+++ b/defaults/preferences/foxtrick.js
@@ -283,6 +283,8 @@ pref("extensions.foxtrick.prefs.module.MatchSimulator.value", 0);
 pref("extensions.foxtrick.prefs.module.MatchSimulator.HTMSPrediction.enabled", true);
 pref("extensions.foxtrick.prefs.module.MatchSimulator.UseRatingsModule.enabled", true);
 pref("extensions.foxtrick.prefs.module.MatchSimulator.StaminaPrediction.enabled", true);
+pref("extensions.foxtrick.prefs.module.MatchOrderNew.enabled", true);
+pref("extensions.foxtrick.prefs.module.MatchOrderNew.UseRatingsModule.enabled", true);
 pref("extensions.foxtrick.prefs.module.MatchPlayerColouring.enabled", true);
 pref("extensions.foxtrick.prefs.module.MatchPlayerColouring.SeparateOwnPlayerColors.enabled", false);
 pref("extensions.foxtrick.prefs.module.MatchRatingsTweaks.enabled", true);

--- a/manifest.json
+++ b/manifest.json
@@ -192,6 +192,7 @@
 			"content/matches/match-lineup-fixes.js",
 			"content/matches/match-lineup-tweaks.js",
 			"content/matches/match-order.js",
+			"content/matches/match-order-new.js",
 			"content/matches/match-player-colouring.js",
 			"content/matches/match-ratings-tweaks.js",
 			"content/matches/match-report-format.js",

--- a/modules
+++ b/modules
@@ -88,6 +88,7 @@ matches/match-income.js
 matches/match-lineup-fixes.js
 matches/match-lineup-tweaks.js
 matches/match-order.js
+matches/match-order-new.js
 matches/match-player-colouring.js
 matches/match-ratings-tweaks.js
 matches/match-report-format.js


### PR DESCRIPTION
This adds the ratings (e.g. LoddarStats) module to the new match order page.
Tested both in FF and Chrome, works on the actual match order but also on the new "player evaluation" match order page.
I find it very useful, let me now if you think this could be useful to the whole foxtrick community.
