### PR TITLE
Restrict the width of the player info table on the player detail page

### DIFF
--- a/content/pages/player.js
+++ b/content/pages/player.js
@@ -451,6 +451,10 @@ Foxtrick.Pages.Player.getInfoTable = function(doc) {
 	else
 		infoDiv = doc.querySelector('.playerInfo');
 
+	if (infoDiv && isNewDesign && document.querySelector('.transferPlayerSkills') !== null) {
+		infoDiv.style.width="60%";
+	}
+
 	var table = infoDiv.querySelector('table');
 	var isYouth = this.isYouth(doc);
 

--- a/res/staff/foxtrick.json
+++ b/res/staff/foxtrick.json
@@ -1913,6 +1913,11 @@
 			"duty": "supporter",
 			"id": "9999999",
 			"name": "<kickoff98>"
+		},
+		{
+			"duty": "developer",
+			"id": "12693691",
+			"name": "SwanFF"
 		}
 	],
 	"type": "foxtrick",


### PR DESCRIPTION
Texts are too long if wage options are enabled, causing the problem in the div on its right in certain languages (Chinese and Japanese at least as far as I know).

Restrict the width of player info table on player detail page if the skills are visible under the new design.

Current Chinese version behaviour
![current](https://user-images.githubusercontent.com/124539914/216871598-bd5dbfde-c8f3-41d6-b3fa-f82bea98788c.png)

After the fix
![fix](https://user-images.githubusercontent.com/124539914/216871612-bc86d77d-60cc-4ffd-8209-49660b143b6a.png)

Current English verison
![english_current](https://user-images.githubusercontent.com/124539914/216871722-8ab5c14f-1768-4cfd-a5fa-74d3e2727429.png)

English version after the fix
![english_fix](https://user-images.githubusercontent.com/124539914/216871794-d04d731b-871d-4204-93ee-7205c705d4bc.png)
