### PR TITLE
In players.js, use nationalplayers 1.5 rather than the default 1.2 - display specialities on match line-up

### DIFF
--- a/content/pages/players.js
+++ b/content/pages/players.js
@@ -183,6 +183,7 @@ Foxtrick.Pages.Players.getPlayerList = function(doc, callback, options) {
 				all = false;
 			}
 			args.push(['file', 'nationalplayers']);
+			args.push(['version', '1.5']);
 			args.push(['teamId', teamId]);
 			args.push(['actionType', action]);
 			args.push(['showAll', all]);


### PR DESCRIPTION
1.5 brings the players' specialties in the XML, which makes displaying them in MatchLineupTweaks possible. This may not work correctly during fog of war stage.

1.3 to 1.5 also bring changes to supporter-related fields and add avatar and player cards fields, which may have an unexpected impact.

I have **only tested this change through enforcing the version using developer tools breakpoints in the browser**, and have not played with unpacked extension debugging. I have **only checked the impact on the match line-up page**, not elsewhere.

See specialties being displayed:
![image](https://user-images.githubusercontent.com/1204726/232151414-a6141996-a4a4-4dbd-87d8-71f4fa702a39.png)
