### PR TITLE
In lineup-shortcut.js, fix lineup links for NT and U21

### DIFF
--- a/content/shortcuts-and-tweaks/lineup-shortcut.js
+++ b/content/shortcuts-and-tweaks/lineup-shortcut.js
@@ -189,11 +189,17 @@ Foxtrick.modules['LineupShortcut'] = {
 		var url = '/Club/Matches/Match.aspx?matchID=' + opts.matchId +
 			'&TeamId=' + opts.teamId + '&HighlightPlayerID=' + opts.playerId;
 		var link = Foxtrick.createFeaturedElement(doc, this, 'a');
-		if (opts.type == 'youth') {
-			link.href = url + '&YouthTeamId=' + opts.youthTeamId + '&SourceSystem=Youth#tab2';
-		}
-		else {
-			link.href = url + '&SourceSystem=Hattrick#tab2';
+		switch (opts.type) {
+		    case 'youth':
+			    link.href = url + '&YouthTeamId=' + opts.youthTeamId + '&SourceSystem=Youth#tab2';
+			    break;
+		    case 'NT':
+		    case 'U21':
+			    link.href = url + '&SourceSystem=HTOIntegrated#tab2';
+			    break;
+		    default:
+			    link.href = url + '&SourceSystem=Hattrick#tab2';
+			    break;
 		}
 		var src = '';
 		if (opts.type == 'NT')


### PR DESCRIPTION
National team games use the same SourceSystem as tournament, ladder and duel games.

![image](https://user-images.githubusercontent.com/1204726/236244349-cbbcada9-b180-4de4-b553-d2892e2c145b.png)
