### PR TITLE
In match-lineup-tweaks.js, fix display of .5 ratings half-star

### DIFF
--- a/content/matches/match-lineup-tweaks.js
+++ b/content/matches/match-lineup-tweaks.js
@@ -784,7 +784,7 @@ Foxtrick.modules.MatchLineupTweaks = {
 
 		let ratings = doc.querySelectorAll('div.playerRating > span');
 		for (let rating of ratings) {
-			var count = parseInt(rating.textContent, 10);
+			var count = parseFloat(rating.textContent);
 			var ratingsDiv = rating.parentElement;
 			var newDiv = Foxtrick.cloneElement(ratingsDiv, false);
 			Foxtrick.makeFeaturedElement(newDiv, this);


### PR DESCRIPTION
No foxtrick:
![image](https://user-images.githubusercontent.com/1204726/236248339-fe2c73fd-52e4-43a8-9391-2e52c773d4e7.png)
Current code:
![image](https://user-images.githubusercontent.com/1204726/236248368-5d618baf-b138-4716-80b4-5151ebe149d4.png)
With change:
![image](https://user-images.githubusercontent.com/1204726/236248392-24f13bb0-6b63-4e3f-9fcb-1ec6241d2d46.png)

Some CSS tests with super high ratings:
![image](https://user-images.githubusercontent.com/1204726/236249378-88935cfd-0c06-445f-891d-cebc6fbb883c.png)
Darras' 14.5 is a bit hard to see and I think 14.5 stars is somewhat possible for defensive technical forwards.