### PR TITLE
Fix senior team shortcut to last lineup

### DIFF
--- a/content/redirections.js
+++ b/content/redirections.js
@@ -153,8 +153,7 @@ Foxtrick.modules['Redirections'] = {
 
 				case 'lastlineup':
 					{
-						let orders = [...mainBody.querySelectorAll('img.matchOrder')];
-						let match = /** @type {HTMLImageElement?}*/ (orders.pop());
+						let match = mainBody.querySelector('img.matchOrder');
 						let link = match?.closest('a').href;
 						if (link == null)
 							break;

--- a/content/shortcuts-and-tweaks/senior-team-shortcuts.js
+++ b/content/shortcuts-and-tweaks/senior-team-shortcuts.js
@@ -45,8 +45,8 @@ Foxtrick.modules['SeniorTeamShortCuts'] = {
 		// last lineup
 		var li = Foxtrick.createFeaturedElement(doc, this, 'li');
 		var lastmatchlink = doc.createElement('a');
-		lastmatchlink.href = `/Club/Matches/MatchLineup.aspx?MatchID=&TeamID=${teamId}` +
-			'&useArchive=True&redir_to_newlineup=true';
+		lastmatchlink.href = `/Club/Matches/?teamID=${teamId}` +
+			'&redir_to_lastlineup=true';
 		lastmatchlink.textContent = Foxtrick.L10n.getString('LastLineup');
 		lastmatchlink.id = 'foxtrick_content_lastmatch';
 		li.appendChild(lastmatchlink);


### PR DESCRIPTION
- Fix lastlineup redirection

The order of matchs in the Matches page was reversed recently. Thus, we need to use the first lineup, not the last.

Interestingly, the first hit of querySelector is not the first lineup in the list, but the one in the featured last match / next match at the very top of the page.

- Update senior-team-shortcuts to use redir_to_lastlineup

The newlineup redirection was deleted in March.
This aligns SeniorTeamShortcuts with TeamPopupLinks.
This fixes #1698.