### PR TITLE
Fix redir_to_coach after 2023/07 coach reform

### DIFF
--- a/content/redirections.js
+++ b/content/redirections.js
@@ -133,8 +133,7 @@ Foxtrick.modules['Redirections'] = {
 						else {
 							// redirect to other coaches
 							var sidebarBox = doc.querySelector('#sidebar .sidebarBox');
-							coachId = Foxtrick.util.id.findPlayerId(sidebarBox);
-							url = '/Club/Players/Player.aspx?playerId=' + coachId;
+							url = Foxtrick.util.id.findTrainerUrl(sidebarBox);
 						}
 
 					}

--- a/content/redirections.js
+++ b/content/redirections.js
@@ -137,11 +137,6 @@ Foxtrick.modules['Redirections'] = {
 						}
 
 					}
-					else if (/\/Club\/NationalTeam\/NationalTeam/i.test(location)) {
-						var ntinfo = doc.getElementById('teamInfo');
-						coachId = Foxtrick.util.id.findPlayerId(ntinfo);
-						url = '/Club/Players/Player.aspx?playerId=' + coachId;
-					}
 
 					break;
 

--- a/content/util/id.js
+++ b/content/util/id.js
@@ -262,6 +262,24 @@ Foxtrick.util.id.findYouthPlayerId = function(element) {
 
 /**
  * @param  {Element} element
+ * @return {string}
+ */
+Foxtrick.util.id.findTrainerUrl = function(element) {
+	if (!element)
+		return null;
+
+	/** @type {NodeListOf<HTMLAnchorElement>} */
+	let links = element.querySelectorAll('a[href]');
+	for (let link of links) {
+		if (/Club\/Specialists\/Trainer.aspx/i.test(link.href)) {
+			return link.href;
+		}
+	}
+	return null;
+};
+
+/**
+ * @param  {Element} element
  * @return {number}
  */
 Foxtrick.util.id.findLeagueLeveUnitId = function(element) {


### PR DESCRIPTION
This fixes #1706.

- [Fix redir_to_coach (open specialist page)](https://github.com/minj/foxtrick/commit/5c734cdf70767050c40d12cef89b972132044761)

The recent coach reform changed the Hattrick-generated link from the player page to the specialist page.
The player page barely contain any information about the coach status (salary + link to specialist page), so there is no point in opening it.

Trying to redirect to a null URL is a no-op operation, so in case of error, we would only open the Players page.

- [In redir_to_coach, remove NT coach redirection code](https://github.com/minj/foxtrick/commit/1c097de1d95231bab05db2e25a53478b3a3b6103)

This feature has been removed from Hattrick for a few years at this point.