### PR TITLE
Fix getPromotionDate computation for youth players joining at 16+ y.o.

### DIFF
--- a/content/pages/youth-player.js
+++ b/content/pages/youth-player.js
@@ -60,7 +60,6 @@ Foxtrick.Pages.YouthPlayer.getPromotionDate = function(doc) {
 			if (!joinedDate)
 				return null;
 
-			Foxtrick.util.time.setMidnight(joinedDate);
 			let seasonDate = Foxtrick.util.time.addDaysToDate(joinedDate, DAYS_IN_SEASON);
 
 			let today = Foxtrick.util.time.getHTDate(doc);


### PR DESCRIPTION
A player has to have been in a team for a full season (i.e. 112 _full_ days) before being promoted. For players that joined at 16 y.o., the hour at which they were hired must be taken into account.
