### PR TITLE
[math.js] Fix Predict.stamina for players at exactly 8.00 stamina

### DIFF
--- a/content/util/math.js
+++ b/content/util/math.js
@@ -119,9 +119,20 @@ Foxtrick.Predict.averageEnergy90 = function(stamina) {
  * @return {number}            1-based stamina level
  */
 Foxtrick.Predict.stamina = function(energyAt90) {
-	return energyAt90 <= 0.887 ?
-		energyAt90 * 10.1341 - 0.9899 :
-		8 + (energyAt90 - 0.887) / 0.1792;
+	/**
+	* Expected energyAt90, based on https://www.hattrick.org/goto.ashx?path=/Forum/Read.aspx?t=17552577&v=0&a=1&n=7
+	* - maxStamina(33 y.o.) === 8.00 --> 0.885 (exact value)
+	* - maxStamina(34 y.o.) === 7.50 --> 0.839...
+	* - maxStamina(35 y.o.) === 7.00 --> 0.793...
+	* The formula below currently returns 8.00, 7.51 and 7.05 for these values.
+	*/
+	if (energyAt90 < 0.885)
+		return energyAt90 * 10.1341 - 0.9899;
+	
+	if (energyAt90 < 0.887)
+		return 8;
+	
+	return 8 + (energyAt90 - 0.887) / 0.1792;
 };
 
 /**


### PR DESCRIPTION
Players at exactly stamina 8.00 (that is, 33 y.o. players) are well-known to be displayed as having 7.98 stamina in MatchLineupTweaks, despite having a visible 8 stamina in Hattrick.
Tweaking the formula impacts players at 8.00 stamina and those slightly above. For instance, energyAt90 === 0.88699 are upgraded from a computed stamina of 7.9989 to 8.0111, which may or may not be correct, but at least is in 8+ territory.
It should also be noted that the formula change does not try to keep the function continuous at its breakpoint, as `Foxtrick.Predict.stamina(0.88499)` now returns 7.978677159, while it most likely should be way closer to 8.00.