### PR TITLE
Update HO URL

### DIFF
--- a/res/staff/ho.json
+++ b/res/staff/ho.json
@@ -1,6 +1,6 @@
 {
     "type": "ho",
-    "url": "https://akasolace.github.io/HO/",
+    "url": "https://ho-dev.github.io/HattrickOrganizer/",
     "duties": {
         "developer": {
             "alt": "HO developer"
@@ -72,11 +72,6 @@
             "id": "9100817",
             "name": "DavidatorusF",
             "duty": "helper"
-        },
-        {
-            "id": "13441219",
-            "name": "capitaineFro",
-            "duty": "developer"
         },
         {
             "id": "13458976",


### PR DESCRIPTION
The Hattrick Organizer repo has now migrated to https://github.com/ho-dev/ ; also remove `captainFro` from the developers' list, as he retired. :-)

<!-- Please review the contributing guidelines before submitting this PR. -->
