### PR TITLE
Fixed Player.getAttributes, which was broken by full-body update

### DIFF
--- a/content/pages/player.js
+++ b/content/pages/player.js
@@ -254,7 +254,7 @@ Foxtrick.Pages.Player.getAttributes = function(doc) {
 			attrs.form = getNumFromRow(FORM_ROW_NEW);
 			attrs.stamina = getNumFromRow(STAMINA_ROW_NEW);
 
-			personLinks = Foxtrick.toArray(doc.querySelectorAll('#mainBody > p .skill'));
+			personLinks = Foxtrick.toArray(doc.querySelectorAll('.playerInfo > p .skill'));
 		}
 		else {
 			/** @type {HTMLAnchorElement[]} */


### PR DESCRIPTION
The restructuring of Player.aspx by the full-body avatar update on 2023-11-07 caused getAttributes() to no longer capture experience, leadership, loyalty, and player personality attributes.

This meant the player position contribution values in Player.aspx were incorrect.

A modified CSS Selector gets this working again.

<!-- Please review the contributing guidelines before submitting this PR. -->
