### PR TITLE
Fix U21 matches not being recognised for xp calc

### DIFF
--- a/content/information-aggregation/player-stats-experience.js
+++ b/content/information-aggregation/player-stats-experience.js
@@ -283,14 +283,16 @@ Foxtrick.modules.PlayerStatsExperience = {
 						'nt_cup_europe',
 						'nt_cup_americas',
 						'nt_cup_africa',
-						'nt_cup_asia',
+						'nt_cup_asia'
 					];
-					if (CONT_CUPS.includes(gameIcon)) {
-						// weeks 11-12 are KO
-						// eslint-disable-next-line no-magic-numbers
-						return !isFinalSeason && week >= 11
-							? 'matchNtContinentalKO'
-							: 'matchNtContinental';
+					for (var contCupName of CONT_CUPS) {
+						if (gameIcon.includes(contCupName)) { // also catch u21, which has the addition "_u21" at the end
+							// weeks 11-12 are KO
+							// eslint-disable-next-line no-magic-numbers
+							return !isFinalSeason && week >= 11
+								? 'matchNtContinentalKO'
+								: 'matchNtContinental';
+						}
 					}
 
 					Foxtrick.log("WARNING: Unmatched gameIcon for NT", gameIcon); // TODO: Can this even happen?


### PR DESCRIPTION
The updated code in function getGameType wasn't catching U21 continental cup matches. Adding the relevant icon names to the CONT_CUPS list fixes this.

<!-- Please review the contributing guidelines before submitting this PR. -->
