### PR TITLE
[ElectionTable] Fix candidates count

### DIFF
--- a/content/information-aggregation/election-table.js
+++ b/content/information-aggregation/election-table.js
@@ -50,7 +50,7 @@ Foxtrick.modules['ElectionTable'] = {
 				for (var i = 0; i < lis.length; ++i) {
 					var imgs = lis[i].getElementsByTagName('img');
 					// count only if not withdrawn
-					if (imgs.length < 2 || imgs[1].src.search(/withdrawnStamp/i) != -1)
+					if (imgs.length < 2 || imgs[1].src.search(/withdrawnStamp/i) == -1)
 						++sum;
 				}
 


### PR DESCRIPTION
The previous code would not count the candidate you voted for, because it had an image, but not the withdrawn stamp.

I don't have an example where I can test it, but I suspect the withdrawn candidates were also counted in.